### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add `nuxt-icon-tw` dependency to your project (it does require Tailwind of cours
 
 ```bash
 npx nuxi@latest module add icon-tw
+npx nuxi@latest module add tailwindcss
 ```
 
 Add it to the `modules` array in your `nuxt.config.ts`:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,7 @@ Falls back to API calls for collections not loaded locally
 Add `nuxt-icon-tw` dependency to your project (it does require Tailwind of course):
 
 ```bash
-# npm
-npm install --save-dev nuxt-icon-tw @nuxtjs/tailwindcss
-
-# Using yarn
-yarn add --dev nuxt-icon-tw @nuxtjs/tailwindcss
+npx nuxi@latest module add icon-tw
 ```
 
 Add it to the `modules` array in your `nuxt.config.ts`:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
