### PR TITLE
chore(linter): fix typecheck error

### DIFF
--- a/src/runtime/Icon.vue
+++ b/src/runtime/Icon.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   tw?: boolean
 }>()
 
-const appConfig = useAppConfig() as {
+const appConfig = useAppConfig() as unknown as {
   nuxtIcon: {
     size?: string
     class?: string

--- a/src/runtime/IconSvg.vue
+++ b/src/runtime/IconSvg.vue
@@ -7,7 +7,7 @@ import { ref, computed, watch } from 'vue'
 import { useAppConfig, useNuxtApp, useState } from '#imports'
 
 const nuxtApp = useNuxtApp()
-const appConfig = useAppConfig() as {
+const appConfig = useAppConfig() as unknown as {
   nuxtIcon: {
     size?: string
     class?: string

--- a/src/runtime/IconTw.vue
+++ b/src/runtime/IconTw.vue
@@ -2,13 +2,14 @@
 import { computed } from 'vue'
 import { useAppConfig } from '#imports'
 
-const appConfig = useAppConfig() as {
+const appConfig = useAppConfig() as unknown as {
   nuxtIcon: {
     size?: string
     class?: string
     aliases?: Record<string, string>
   }
 }
+
 
 const props = defineProps({
   name: {


### PR DESCRIPTION
Fix error when running `nuxi generate` when type check is activated. I know that is not a clean way.

```console
node_modules/.pnpm/nuxt-icon-tw@0.1.3_@nuxtjs+tailwindcss@6.12.0_rollup@4.17.2_ts-node@10.9.2_@swc+core@1.4.17_@_dmp2fs736wffqmjuqie53ju5j4/node_modules/nuxt-icon-tw/dist/runtime/IconTw.vue:5:19 - error TS2352: Conversion of type 'AppConfig' to type '{ nuxtIcon: { size?: string | undefined; class?: string | undefined; aliases?: Record<string, string> | undefined; }; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Property 'nuxtIcon' is missing in type 'AppConfig' but required in type '{ nuxtIcon: { size?: string | undefined; class?: string | undefined; aliases?: Record<string, string> | undefined; }; }'.

  5 const appConfig = useAppConfig() as {
                      ~~~~~~~~~~~~~~~~~~~
  6   nuxtIcon: {
    ~~~~~~~~~~~~~
... 
 10   }
    ~~~
 11 }
    ~

  node_modules/.pnpm/nuxt-icon-tw@0.1.3_@nuxtjs+tailwindcss@6.12.0_rollup@4.17.2_ts-node@10.9.2_@swc+core@1.4.17_@_dmp2fs736wffqmjuqie53ju5j4/node_modules/nuxt-icon-tw/dist/runtime/IconTw.vue:6:3
    6   nuxtIcon: {
        ~~~~~~~~
    'nuxtIcon' is declared here.

```